### PR TITLE
Handle ISO 8601 'Z' timestamps

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -25,6 +25,16 @@ DATABASE_URL = os.getenv("DATABASE_URL") or "postgresql://postgres:postgres@data
 app = FastAPI(title="Market Intelligence API", version="0.1.0")
 
 
+def _parse_iso8601(value: str) -> dt.datetime:
+    """Parse an ISO8601 timestamp string.
+
+    Python's ``datetime.fromisoformat`` does not handle the "Z" suffix that many
+    APIs use to denote UTC.  This helper accepts such values by translating the
+    suffix to ``+00:00`` before parsing.
+    """
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
 @app.on_event("startup")
 async def startup_event():
     # Create a connection pool to the database
@@ -58,11 +68,11 @@ async def company_history(ticker: str, start: Optional[str] = None, end: Optiona
     """
     # Parse dates
     try:
-        end_dt = dt.datetime.fromisoformat(end) if end else dt.datetime.utcnow()
+        end_dt = _parse_iso8601(end) if end else dt.datetime.utcnow()
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid end date format")
     try:
-        start_dt = dt.datetime.fromisoformat(start) if start else end_dt - dt.timedelta(days=7)
+        start_dt = _parse_iso8601(start) if start else end_dt - dt.timedelta(days=7)
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid start date format")
     if start_dt >= end_dt:

--- a/ingest-news/main.py
+++ b/ingest-news/main.py
@@ -51,6 +51,11 @@ def connect_db():
     return psycopg2.connect(DATABASE_URL)
 
 
+def _parse_iso8601(value: str) -> dt.datetime:
+    """Parse an ISO8601 timestamp string, supporting a trailing 'Z'."""
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
 class CompanyCache:
     """A simple in‑memory cache for ticker → company_id lookups."""
 
@@ -206,7 +211,12 @@ def fetch_and_process_news(conn, model=None, tokenizer=None) -> List[Dict[str, A
         tickers = extract_tickers(text)
         if not tickers:
             continue
-        timestamp = dt.datetime.fromisoformat(article.get("publishedAt", dt.datetime.utcnow().isoformat()))
+        published_at = article.get("publishedAt")
+        try:
+            timestamp = _parse_iso8601(published_at) if published_at else dt.datetime.utcnow()
+        except Exception:
+            logger.warning(f"Unable to parse publishedAt value: {published_at!r}")
+            timestamp = dt.datetime.utcnow()
         s_score, pos, neu, neg = infer_sentiment(model, tokenizer, text)
         items.append(
             {


### PR DESCRIPTION
## Summary
- add `_parse_iso8601` utility for parsing timestamps with trailing `Z`
- apply helper in API history endpoint and news ingestion to avoid parsing errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68981d9ecd9c8327881d262704992c0a